### PR TITLE
Added suggestion for Website attribute in meta data

### DIFF
--- a/openproject.ini
+++ b/openproject.ini
@@ -31,6 +31,7 @@ Contact=info@openproject.com
 NotifyVendor=True
 NotificationEmail=n.lindenthal@openproject.com
 WebsiteVendor=https://www.openproject.org
+Website=https://www.openproject.org/collaboration-software-features/
 Categories=Collaboration,Business
 SupportURL=https://www.openproject.org/professional-services/maintenance-and-support/
 
@@ -59,3 +60,4 @@ LongDescription=<p>OpenProject ist die führende Open Source Projekt Management 
  <li>Einfache Wartung: Die OpenProject GmbH stellt regelmäßig Software- und Security-Updates über das App Center zur Verfügung. Diese können einfach über den integrierten Update Mechanismus des App Centers installiert werden.</li>
  <li>Einfache Nutzung: Zentrale Nutzerverwaltung und Authentifizierung per Single-Sign-On.</li>.
  </ul>
+Website=https://www.openproject.org/de/funktionen/


### PR DESCRIPTION
Currently the user is only directed to the vendors website. I suggest to also
provide a link to the OpenProject functions and features. The user can find this information
easier on the website.