### PR TITLE
Update README files and emphasize primary mailadresse

### DIFF
--- a/dist/openproject.README_DE
+++ b/dist/openproject.README_DE
@@ -8,9 +8,31 @@
 	Integriert in das UCS Identity Management
 </h2>
 <p>
-	Benutzer können einfach über den Reiter &quot;Apps&quot; im &quot;Benutzer&quot;-Modul für OpenProject freigeschaltet werden, indem &quot;Nutzer für OpenProject aktivieren&quot; angeklickt wird. Über das Häkchen &quot;Admin-Rechte für OpenProject&quot; kann man dem Nutzer darüber hinaus noch Admin-Rechte geben. Bitte stellen Sie sicher, dass der Benutzer eine primäre E-Mailadresse gesetzt hat.
-	<br>
+	Damit Benutzer sich an OpenProject anmelden können, müssen die folgenden Schritte abgeschlossen werden:
 </p>
+<ol>
+	<li>
+		Erstellen Sie eine E-Mail Domäne für Ihre UCS-Umgebung unter <i>Domäne</i> → <i>E-Mail</i>, z.B. &quot;ucs.example&quot;
+	</li>
+	<li>
+		Erstellen Sie ein Benutzerkonto für jeden Benutzer, der sich an OpenProject anmelden können soll.
+	</li>
+</ol>
+<p>
+	<b>Hinweis</b>:
+</p>
+<ul>
+	<li>
+		Bitte stellen Sie sicher, dass die erforderlichen Attribute angegeben sind und dass Sie eine <b>primäre E-Mailadresse</b> für den Benutzer vergeben.
+	</li>
+	<li>
+		Des Weiteren müssen Sie den Benutzer aktivieren, indem Sie im Benutzer Modul im Reiter <i>Apps</i> auf <i>Nutzer für OpenProject aktivieren</i> klicken.
+		<br>
+	</li>
+	<li>
+		Über die Checkbox <i>Admin-Rechte für OpenProject</i> kann man dem Benutzer darüber hinaus noch Admin-Rechte vergeben.
+	</li>
+</ul>
 <p>
 	Sobald Sie in OpenProject eingeloggt sind, sollten Sie als erstes das Standard Adminkonto deaktivieren, das bei der Installation automatisch erstellt wird.
 </p>

--- a/dist/openproject.README_EN
+++ b/dist/openproject.README_EN
@@ -8,9 +8,31 @@
 	Integrated into the UCS Identity Management
 </h2>
 <p>
-	Users may be activated by in UCS by clicking on &quot;Activate user for OpenProject&quot; in the module &quot;Users&quot; (tab &quot;Apps&quot;). The checkbox &quot;Give admin rights to OpenProject&quot; controls whether the user is also an admin for OpenProject. Please make sure that the user has a &quot;Primary email address&quot; definied.
-	<br>
+	To enable users for login in OpenProject, please complete the following steps:
 </p>
+<ol>
+	<li>
+		Create a mail domain for your UCS environment at <i>Domain</i> → <i>Mail</i>, e.g. &quot;ucs.example&quot;
+	</li>
+	<li>
+		Create a user account for each user that should login to OpenProject.
+	</li>
+</ol>
+<p>
+	<b>Note</b>:
+</p>
+<ul>
+	<li>
+		Please make sure to provide the required attributes and assign a <b>primary email address</b> for the user.
+	</li>
+	<li>
+		Furthermore, you need to enable the user by clicking on <i>Activate user for OpenProject</i> in the module <i>Users</i> under the tab <i>Apps</i>.
+		<br>
+	</li>
+	<li>
+		The checkbox <i>Give admin rights to OpenProject</i> controls whether the user is also an admin for OpenProject.
+	</li>
+</ul>
 <p>
 	Once you're logged in to OpenProject, you should make sure to disable the default admin account that was automatically created.
 </p>


### PR DESCRIPTION
Users in OpenProject require a primary mail address to be set. A hint has
already been present. I emphasized it more and made it more explicit.